### PR TITLE
Fix for CircleCI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,10 +29,20 @@ jobs:
 
 workflows:
   version: 2
-
-  build_and_publish:
+  build-only:
     jobs:
-      - build
+      - build:
+          filters:
+            tags:
+              ignore: /^v.*/
+  build-and-publish:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
       - publish:
           filters:
             tags:


### PR DESCRIPTION
This actually pushes tagged releases to Anaconda cloud