### PR TITLE
Select Conda Python for reticulate and auto-install pydbtools

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dbtools
 Type: Package
 Title: Uses R wrapper function to send queries to athena.
-Version: 2.0.2
+Version: 2.0.3
 Author: Karik Isichei
 Maintainer: The package maintainer <yourself@somewhere.net>
 Description: See title.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,3 +17,9 @@ Suggests:
   data.table (>= 1.11.8)
 Remotes:
   moj-analytical-services/s3tools
+Config/reticulate:
+  list(
+    packages = list(
+      list(package = "pydbtools", pip = TRUE)
+    )
+  )

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,3 @@
+.onLoad <- function(libname, pkgname) {
+  reticulate::configure_environment(pkgname)
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,5 +1,5 @@
 .onLoad <- function(libname, pkgname) {
   if(!reticulate::py_module_available("pydbtools")) {
-    reticulate::conda_install(packages = "pydbtools", pip = TRUE)
+    reticulate::conda_install(envname = "rstudio", packages = "pydbtools", pip = TRUE)
   }
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,7 +1,10 @@
 .onLoad <- function(libname, pkgname) {
+  # Construct Python path and pass it to reticulate
   base_path <- strsplit(Sys.getenv("PATH"), ":")[[1]][1]
   python_path <- paste(base_path, "/python", sep = "")
   reticulate::use_python(python_path)
+
+  # Check if pydbtools is installed. If it isn't, install it through Conda
   if(!reticulate::py_module_available("pydbtools")) {
     reticulate::conda_install(envname = "rstudio", packages = "pydbtools==2.0.1", pip = TRUE)
   }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,4 +1,5 @@
 .onLoad <- function(libname, pkgname) {
+  reticulate::use_python(".conda/envs/rstudio/bin/python")
   if(!reticulate::py_module_available("pydbtools")) {
     reticulate::conda_install(envname = "rstudio", packages = "pydbtools==2.0.0", pip = TRUE)
   }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,3 +1,5 @@
 .onLoad <- function(libname, pkgname) {
-  reticulate::configure_environment(pkgname)
+  if(!reticulate::py_module_available("pydbtools") {
+    reticulate::conda_install(packages = "pydbtools", pip = TRUE)
+  }
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,5 +1,5 @@
 .onLoad <- function(libname, pkgname) {
-  if(!reticulate::py_module_available("pydbtools") {
+  if(!reticulate::py_module_available("pydbtools")) {
     reticulate::conda_install(packages = "pydbtools", pip = TRUE)
   }
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,6 +1,6 @@
 .onLoad <- function(libname, pkgname) {
-  base_path = strsplit(Sys.getenv("PATH"), ":")[[1]][1]
-  python_bath = paste(base_path, "/python", sep = "")
+  base_path <- strsplit(Sys.getenv("PATH"), ":")[[1]][1]
+  python_path <- paste(base_path, "/python", sep = "")
   reticulate::use_python(python_path)
   if(!reticulate::py_module_available("pydbtools")) {
     reticulate::conda_install(envname = "rstudio", packages = "pydbtools==2.0.1", pip = TRUE)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,5 +1,7 @@
 .onLoad <- function(libname, pkgname) {
-  reticulate::use_python(".conda/envs/rstudio/bin/python")
+  base_path = strsplit(Sys.getenv("PATH"), ":")[[1]][1]
+  python_bath = paste(base_path, "/python", sep = "")
+  reticulate::use_python(python_path)
   if(!reticulate::py_module_available("pydbtools")) {
     reticulate::conda_install(envname = "rstudio", packages = "pydbtools==2.0.0", pip = TRUE)
   }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,5 +1,5 @@
 .onLoad <- function(libname, pkgname) {
   if(!reticulate::py_module_available("pydbtools")) {
-    reticulate::conda_install(envname = "rstudio", packages = "pydbtools=1.0.3", pip = TRUE)
+    reticulate::conda_install(envname = "rstudio", packages = "pydbtools==1.0.3", pip = TRUE)
   }
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,5 +1,5 @@
 .onLoad <- function(libname, pkgname) {
   if(!reticulate::py_module_available("pydbtools")) {
-    reticulate::conda_install(envname = "rstudio", packages = "pydbtools==1.0.3", pip = TRUE)
+    reticulate::conda_install(envname = "rstudio", packages = "pydbtools==2.0.0", pip = TRUE)
   }
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,5 +1,5 @@
 .onLoad <- function(libname, pkgname) {
   if(!reticulate::py_module_available("pydbtools")) {
-    reticulate::conda_install(envname = "rstudio", packages = "pydbtools", pip = TRUE)
+    reticulate::conda_install(envname = "rstudio", packages = "pydbtools=1.0.3", pip = TRUE)
   }
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -3,6 +3,6 @@
   python_bath = paste(base_path, "/python", sep = "")
   reticulate::use_python(python_path)
   if(!reticulate::py_module_available("pydbtools")) {
-    reticulate::conda_install(envname = "rstudio", packages = "pydbtools==2.0.0", pip = TRUE)
+    reticulate::conda_install(envname = "rstudio", packages = "pydbtools==2.0.1", pip = TRUE)
   }
 }

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ When you run a query in SQL against our databases you are using Athena. When Ath
 ## 2.0.3 - 2020-04-29
 
 - Automatically install `pydbtools` to your environment on install
+- Fixed prompts to install miniconda - now automatically uses main Analytical Platform Conda Python, based on sys path
 
 ## 2.0.2 - 2019-06-14
 


### PR DESCRIPTION
Adds a zzz.R file with 2 actions when the package is loaded:

- select the main Conda Python installation based on env variable - this should stop the prompts to install miniconda
- install pydbtools if it isn't already there

Keeping this in draft until the 2.0.1 release of pydbtools is done